### PR TITLE
feat: 移動せずに向きを変えるTurnコマンドを追加

### DIFF
--- a/src/core/dungeon.rs
+++ b/src/core/dungeon.rs
@@ -292,6 +292,10 @@ impl GameState {
                 }
                 self.throw_item(idx, &mut events);
             }
+            GameCommand::Turn(dir) => {
+                self.player.direction = dir;
+                turn_consumed = false;
+            }
             GameCommand::Wait => {}
             GameCommand::OpenInventory => {
                 events.push(GameEvent::RequestInventory);

--- a/src/core/turn.rs
+++ b/src/core/turn.rs
@@ -3,6 +3,7 @@ use super::types::{Direction, Position};
 #[derive(Debug, Clone)]
 pub enum GameCommand {
     Move(Direction),
+    Turn(Direction),    // change facing direction without moving (no turn consumed)
     UseItem(usize),     // inventory index
     UseStaff(usize),    // inventory index (staff item)
     EquipWeapon(usize), // inventory index (weapon item)

--- a/src/ui/terminal/input.rs
+++ b/src/ui/terminal/input.rs
@@ -1,4 +1,4 @@
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use crossterm::event::{self, Event, KeyCode, KeyEventKind, KeyModifiers};
 
 use crate::core::turn::GameCommand;
 use crate::core::types::Direction;
@@ -19,8 +19,24 @@ impl InputHandler for TerminalInput {
         loop {
             match event::read()? {
                 Event::Key(key) if key.kind == KeyEventKind::Press => {
+                    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
                     let cmd = match key.code {
                         KeyCode::Char('q') => GameCommand::Quit,
+                        // Shift+direction: turn without moving
+                        KeyCode::Char('H') => GameCommand::Turn(Direction::Left),
+                        KeyCode::Char('J') => GameCommand::Turn(Direction::Down),
+                        KeyCode::Char('K') => GameCommand::Turn(Direction::Up),
+                        KeyCode::Char('L') => GameCommand::Turn(Direction::Right),
+                        KeyCode::Char('Y') => GameCommand::Turn(Direction::UpLeft),
+                        KeyCode::Char('U') => GameCommand::Turn(Direction::UpRight),
+                        KeyCode::Char('N') => GameCommand::Turn(Direction::DownLeft),
+                        KeyCode::Char('M') => GameCommand::Turn(Direction::DownRight),
+                        // Shift+arrow keys: turn without moving
+                        KeyCode::Left if shift => GameCommand::Turn(Direction::Left),
+                        KeyCode::Down if shift => GameCommand::Turn(Direction::Down),
+                        KeyCode::Up if shift => GameCommand::Turn(Direction::Up),
+                        KeyCode::Right if shift => GameCommand::Turn(Direction::Right),
+                        // Normal direction: move
                         KeyCode::Char('h') | KeyCode::Left => GameCommand::Move(Direction::Left),
                         KeyCode::Char('j') | KeyCode::Down => GameCommand::Move(Direction::Down),
                         KeyCode::Char('k') | KeyCode::Up => GameCommand::Move(Direction::Up),


### PR DESCRIPTION
## Summary
- プレイヤーが移動せずに向き（facing direction）だけを変更できる `Turn(Direction)` コマンドを追加
- 投擲や杖の使用前に任意の方向へ照準を合わせられるようになる

## Changes
- `GameCommand::Turn(Direction)` バリアントを追加 (`src/core/turn.rs`)
- `process_turn` で `Turn` を処理（向きのみ更新、ターン消費なし）(`src/core/dungeon.rs`)
- Shift+方向キー（Shift+HJKLYUNM / Shift+矢印）で `Turn` を入力可能に (`src/ui/terminal/input.rs`)

## Testing
1. `cargo build` / `cargo test` — 全103テスト合格
2. ゲーム内で以下を確認:
   - Shift+方向キーで向きが変わり、移動しないこと
   - ターンが消費されないこと（モンスターが動かない）
   - 向き変更後に `t`（投擲）で正しい方向に飛ぶこと

## Checklist
- [x] Tests pass
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)